### PR TITLE
Resolve dataset preparation discrepancy for elasticity, darcy problems

### DIFF
--- a/LNO-PyTorch/ForwardProblem/prepare.py
+++ b/LNO-PyTorch/ForwardProblem/prepare.py
@@ -57,10 +57,10 @@ if __name__ == "__main__":
         not os.path.exists(os.path.join(DATA_PATH, "{}_val.npy".format(arg.data_name))):
         print("Preparing data...")
         if arg.data_name == "Darcy":
-            SRC_RES = 241
-            OBJ_RES = 241
-            TRAIN_NUM = 1024
-            VAL_NUM = 1024
+            SRC_RES = 421
+            OBJ_RES = 85
+            TRAIN_NUM = 1000
+            VAL_NUM = 200
             x, y1, y2 = load_Darcy(os.path.join(DATA_PATH, "piececonst_r{}_N1024_smooth1.mat".format(SRC_RES)), SRC_RES, OBJ_RES)
             tx, ty1, ty2 = load_Darcy(os.path.join(DATA_PATH, "piececonst_r{}_N1024_smooth2.mat".format(SRC_RES)), SRC_RES, OBJ_RES)
             x = np.concatenate((x, tx), axis=0)
@@ -91,7 +91,7 @@ if __name__ == "__main__":
             split_and_save(arg.data_name, x, y1, y2, TRAIN_NUM, VAL_NUM)
         elif arg.data_name == "Elasticity":
             TRAIN_NUM = 1000
-            VAL_NUM = 1000
+            VAL_NUM = 200
             rr = np.load(os.path.join(DATA_PATH, "Random_UnitCell_rr_10.npy"))
             sigma = np.load(os.path.join(DATA_PATH, "Random_UnitCell_sigma_10.npy"))
             theta = np.load(os.path.join(DATA_PATH, "Random_UnitCell_theta_10.npy"))


### PR DESCRIPTION
Hi LNO Authors,

I understand that you have based your experimental setup on that of [Transolver](https://github.com/thuml/Transolver), and that you make direct comparison with their results in your [paper](https://arxiv.org/abs/2406.03923). As such, I wanted to inform you of discrepancies in the data preparation stage between your experimental setup and that of Transolver which result in substantial changes in validation loss.

## Elasticity dataset

|            | Data File                    | Num Train | Num Test |
|------------|------------------------------|-----------|----------|
| Transolver | Random_UnitCell_sigma_10.npy | 1000      | 200      |
| LNO.       | Random_UnitCell_sigma_10.npy | 1000      | 1000     |

Transolver (based on [Transolver/PDE-SolvingStandardBenchmark/exp_elas.py](https://github.com/thuml/Transolver/blob/main/PDE-Solving-StandardBenchmark/exp_elas.py)) uses 200 cases for the test set, whereas LNO uses 1000.

On master:
```
$ ./scripts/LNO_Elasticity.sh
Epoch: 500      Learning Rate :1.0246740125861636e-11   Train Loss: 0.0040976484306156635   Val Loss: 0.005123566836118698
Finish Training !
```

On this branch:
```
$ ./scripts/LNO_Elasticity.sh
Epoch: 500      Learning Rate :1.0246740125861636e-11   Train Loss: 0.0040976484306156635   Val Loss: 0.01531931385397911
Finish Training !
```

This dramatically changes the validation loss from `0.0051` to `0.0153`.

## Darcy dataset

|            | Data File                             | Training Resolution| Num Train | Num Test |
|------------|---------------------------------------|--------------------|-----------|----------|
| Transolver | piececonst_r421_N1024_smooth{1,2}.mat | 85 x 85            | 1000      | 200      |
| LNO.       | piececonst_r241_N1024_smooth{1,2}.mat | 241 x 241          | 1024      | 1024     |

Transolver (based on [Transolver/PDE-SolvingStandardBenchmark/exp_darcy.py](https://github.com/thuml/Transolver/blob/main/PDE-Solving-StandardBenchmark/exp_darcy.py)) and LNO use different dataset files, different train/test splits, and training resolutions.

On master:
```
$ ./scripts/LNO_Darcy.sh
Epoch: 500      Learning Rate :1.3764955254324295e-11   Train Loss: 0.003548223525285721        Val Loss: 0.005500853061676025
Finish Training !
```

On this branch:
```
$ ./scripts/LNO_Darcy.sh
Epoch: 500      Learning Rate :1.401177331784148e-11    Train Loss: 0.008193107321858406        Val Loss: 0.009375382214784622
Finish Training !
```

This changes the validation loss form `0.0055` to `0.0093`.

---
We would greatly appreciate it if you could share the code for all the comparison models that were used. Running them within a unified codebase would help ensure consistency and avoid similar discrepancies. Additionally, the preparation scripts for other datasets may also contain similar issues that would benefit from a thorough examination.

Best,
Vedant Puri